### PR TITLE
Adds 'custom' cap_interval_id

### DIFF
--- a/lib/soapy_cake/const.rb
+++ b/lib/soapy_cake/const.rb
@@ -53,7 +53,8 @@ module SoapyCake
         indefinite: 0,
         daily: 1,
         weekly: 2,
-        monthly: 3
+        monthly: 3,
+        custom: 4
       },
       creative_type_id: {
         link: 1,


### PR DESCRIPTION
`SoapyCake::Const::CONSTS[:cap_interval_id]` is missing the "Custom" cap interval (`id=4`).

See related error here: https://app.honeybadger.io/projects/35651/faults/14627068