### PR TITLE
adds validation of fetched rows in validation

### DIFF
--- a/lib/soapy_cake/client.rb
+++ b/lib/soapy_cake/client.rb
@@ -22,9 +22,13 @@ module SoapyCake
       request.api_key = api_key
       request.time_offset = time_offset
 
-      Response
+      r = Response
         .new(response_body(request), request.short_response?, time_offset)
-        .public_send(:"to_#{xml_response? ? 'xml' : 'enum'}")
+      content = r.public_send(:"to_#{xml_response? ? 'xml' : 'enum'}")
+
+      return content, r.total_rows, r.number_of_elements if opts[:batch_mode]
+
+      content
     end
 
     private

--- a/lib/soapy_cake/response.rb
+++ b/lib/soapy_cake/response.rb
@@ -29,6 +29,15 @@ module SoapyCake
       (empty? ? [] : [body.to_s]).to_enum
     end
 
+    def total_rows
+      body.to_s.scan(%r{<row_count>(\d+)<\/row_count>}).flatten.first.to_i
+    end
+
+    def number_of_elements
+      depth = short_response ? SHORT_ELEMENT_DEPTH : ELEMENTS_DEPTH
+      sax.at_depth(depth).count
+    end
+
     private
 
     def empty?


### PR DESCRIPTION
We observed some strange behaviour when calling the CAKE API in batch mode fashion, i.e., calling it with high frequency can lead to empty responses without throwing an error. This PR is supposed to add some basic check functionality to assure that the total number of rows fetched in batch mode matches the number of rows reported by Cake to be contained in the total response. Please comment on this solution, would be glad if someone could suggest somewhat more clean.