### PR TITLE
Small speed/mem/style improvements

### DIFF
--- a/lib/soapy_cake/helper.rb
+++ b/lib/soapy_cake/helper.rb
@@ -26,8 +26,8 @@ module SoapyCake
     def translate_booleans(opts)
       opts.transform_values do |v|
         case v
-        when true then 'on'
-        when false then 'off'
+        when true then 'on'.freeze
+        when false then 'off'.freeze
         else v
         end
       end

--- a/lib/soapy_cake/request.rb
+++ b/lib/soapy_cake/request.rb
@@ -40,9 +40,9 @@ module SoapyCake
     end
 
     def xml_params(xml)
-      xml.api_key api_key
+      xml.api_key(api_key)
       opts.each do |k, v|
-        xml.public_send(k.to_sym, format_param(k, v))
+        xml.public_send(k, format_param(k, v))
       end
     end
 
@@ -56,7 +56,7 @@ module SoapyCake
     def format_param(key, value)
       return time_converter.to_cake(value) if DATE_CLASSES.include?(value.class)
 
-      if key.to_s.end_with?('_date')
+      if key.to_s.end_with?('_date'.freeze)
         fail Error, "You need to use a Time/DateTime/Date object for '#{key}'"
       end
 

--- a/lib/soapy_cake/response.rb
+++ b/lib/soapy_cake/response.rb
@@ -64,7 +64,7 @@ module SoapyCake
     end
 
     def error_check_success!
-      return if sax.for_tag(:success).first == 'true'
+      return if sax.for_tag(:success).first == 'true'.freeze
       fail RequestFailed, error_message
     end
 

--- a/lib/soapy_cake/response_value.rb
+++ b/lib/soapy_cake/response_value.rb
@@ -1,7 +1,6 @@
 module SoapyCake
   class ResponseValue
-    attr_reader :value
-    attr_reader :key
+    attr_reader :key, :value
 
     # Known string ids that should not be parsed as integers
     STRING_IDS = %w(tax_id transaction_id).freeze
@@ -27,11 +26,11 @@ module SoapyCake
     attr_reader :time_converter
 
     def false?
-      value == 'false'
+      value == 'false'.freeze
     end
 
     def true?
-      value == 'true'
+      value == 'true'.freeze
     end
 
     def date?
@@ -39,7 +38,7 @@ module SoapyCake
     end
 
     def id?
-      key.to_s.end_with?('_id')
+      key.end_with?('_id'.freeze)
     end
 
     def string_id?

--- a/lib/soapy_cake/time_converter.rb
+++ b/lib/soapy_cake/time_converter.rb
@@ -14,7 +14,7 @@ module SoapyCake
 
     def to_cake(date)
       date = date.to_datetime if date.is_a?(Date)
-      date.in_time_zone(zone).strftime('%Y-%m-%dT%H:%M:%S')
+      date.in_time_zone(zone).strftime('%Y-%m-%dT%H:%M:%S'.freeze)
     end
 
     def from_cake(value)


### PR DESCRIPTION
Some minor improvements.

I looked into further speed improvements, but could not find a usable solution.
- Parsing the whole tree with Ox is about 4x faster but uses about 4x the memory, because it keeps the whole tree in memory, unlike Saxerator.
- Building a custom streaming parser (with Nokogiri) was about 2x faster than using Saxerator, but is a lot of work to get right and fast. I decided that it's not worth the time and maintenance effort.