### PR TITLE
"replace" geo-targets instead of "add"-ing them

### DIFF
--- a/lib/soapy_cake/admin_addedit.rb
+++ b/lib/soapy_cake/admin_addedit.rb
@@ -111,7 +111,7 @@ module SoapyCake
       run Request.new(:admin, :addedit, :contact, opts)
     end
 
-    def add_geo_targets(opts)
+    def edit_geo_targets(opts)
       require_params(opts, %i(offer_contract_id allow_countries))
 
       opts = if opts[:allow_countries]
@@ -120,7 +120,7 @@ module SoapyCake
                geo_targets_redirect_options(opts)
              end
 
-      opts = opts.merge(add_edit_option: 'add', set_targeting_to_geo: true)
+      opts = opts.merge(add_edit_option: 'replace', set_targeting_to_geo: true)
 
       run Request.new(:admin, :addedit, :geo_targets, opts)
     end

--- a/lib/soapy_cake/client.rb
+++ b/lib/soapy_cake/client.rb
@@ -44,9 +44,8 @@ module SoapyCake
     end
 
     def check_write_enabled!(request)
-      unless request.read_only? || write_enabled
-        raise Error, 'Writes not enabled (pass write_enabled: true or set CAKE_WRITE_ENABLED=yes)'
-      end
+      return if request.read_only? || write_enabled
+      raise Error, 'Writes not enabled (pass write_enabled: true or set CAKE_WRITE_ENABLED=yes)'
     end
 
     def with_retries(&block)
@@ -63,7 +62,7 @@ module SoapyCake
     end
 
     def http_response(request)
-      logger.info("soapy_cake:request #{request}") if logger
+      logger&.info("soapy_cake:request #{request}")
 
       http_request = Net::HTTP::Post.new(request.path, HEADERS)
       http_request.body = request.xml

--- a/spec/fixtures/vcr_cassettes/SoapyCake_AdminAddedit/geo_targeting/creates_geo_targetings.yml
+++ b/spec/fixtures/vcr_cassettes/SoapyCake_AdminAddedit/geo_targeting/creates_geo_targetings.yml
@@ -16,7 +16,7 @@ http_interactions:
               <cake:countries>DE,FR</cake:countries>
               <cake:allow_countries>true</cake:allow_countries>
               <cake:redirect_site_offer_contract_ids>-1,-1</cake:redirect_site_offer_contract_ids>
-              <cake:add_edit_option>add</cake:add_edit_option>
+              <cake:add_edit_option>replace</cake:add_edit_option>
               <cake:set_targeting_to_geo>true</cake:set_targeting_to_geo>
             </cake:GeoTargets>
           </env:Body>
@@ -24,6 +24,12 @@ http_interactions:
     headers:
       Content-Type:
       - application/soap+xml;charset=UTF-8
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
   response:
     status:
       code: 200
@@ -34,21 +40,21 @@ http_interactions:
       Content-Type:
       - application/soap+xml; charset=utf-8
       Server:
-      - Microsoft-IIS/8.0
+      - Microsoft-IIS/8.5
       X-Aspnet-Version:
       - 4.0.30319
       X-Powered-By:
       - ASP.NET
       Date:
-      - Fri, 07 Aug 2015 13:45:43 GMT
+      - Mon, 10 Oct 2016 10:22:33 GMT
       Content-Length:
-      - '446'
+      - '449'
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><soap:Body><GeoTargetsResponse
         xmlns="http://cakemarketing.com/api/3/"><GeoTargetsResult><success>true</success><message>Geotarget(s)
-        Added</message><row_count>2</row_count></GeoTargetsResult></GeoTargetsResponse></soap:Body></soap:Envelope>
+        Replaced</message><row_count>2</row_count></GeoTargetsResult></GeoTargetsResponse></soap:Body></soap:Envelope>
     http_version: 
   recorded_at: Tue, 17 Feb 2015 12:00:00 GMT
 - request:
@@ -67,7 +73,7 @@ http_interactions:
               <cake:countries>AT,CH</cake:countries>
               <cake:allow_countries>false</cake:allow_countries>
               <cake:redirect_site_offer_contract_ids>1392,1392</cake:redirect_site_offer_contract_ids>
-              <cake:add_edit_option>add</cake:add_edit_option>
+              <cake:add_edit_option>replace</cake:add_edit_option>
               <cake:set_targeting_to_geo>true</cake:set_targeting_to_geo>
             </cake:GeoTargets>
           </env:Body>
@@ -75,6 +81,12 @@ http_interactions:
     headers:
       Content-Type:
       - application/soap+xml;charset=UTF-8
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
   response:
     status:
       code: 200
@@ -85,21 +97,21 @@ http_interactions:
       Content-Type:
       - application/soap+xml; charset=utf-8
       Server:
-      - Microsoft-IIS/8.0
+      - Microsoft-IIS/8.5
       X-Aspnet-Version:
       - 4.0.30319
       X-Powered-By:
       - ASP.NET
       Date:
-      - Fri, 07 Aug 2015 13:45:48 GMT
+      - Mon, 10 Oct 2016 10:22:33 GMT
       Content-Length:
-      - '446'
+      - '449'
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><soap:Body><GeoTargetsResponse
         xmlns="http://cakemarketing.com/api/3/"><GeoTargetsResult><success>true</success><message>Geotarget(s)
-        Added</message><row_count>2</row_count></GeoTargetsResult></GeoTargetsResponse></soap:Body></soap:Envelope>
+        Replaced</message><row_count>2</row_count></GeoTargetsResult></GeoTargetsResponse></soap:Body></soap:Envelope>
     http_version: 
   recorded_at: Tue, 17 Feb 2015 12:00:00 GMT
-recorded_with: VCR 2.9.3
+recorded_with: VCR 3.0.1

--- a/spec/integration/soapy_cake/admin_addedit_spec.rb
+++ b/spec/integration/soapy_cake/admin_addedit_spec.rb
@@ -149,14 +149,14 @@ RSpec.describe SoapyCake::AdminAddedit do
 
   describe 'geo targeting' do
     it 'creates geo targetings', :vcr do
-      result = admin_addedit.add_geo_targets(
+      result = admin_addedit.edit_geo_targets(
         offer_contract_id: offer_contract_id,
         countries: %w(DE FR),
         allow_countries: true
       )
       expect(result).to include(success: true, row_count: '2')
 
-      result = admin_addedit.add_geo_targets(
+      result = admin_addedit.edit_geo_targets(
         offer_contract_id: offer_contract_id,
         countries: %w(AT CH),
         redirects: {
@@ -170,7 +170,7 @@ RSpec.describe SoapyCake::AdminAddedit do
 
     it 'fails if it does not get a correct redirect hash' do
       expect do
-        admin_addedit.add_geo_targets(
+        admin_addedit.edit_geo_targets(
           offer_contract_id: offer_contract_id,
           redirects: {},
           allow_countries: false

--- a/spec/integration/soapy_cake/admin_addedit_spec.rb
+++ b/spec/integration/soapy_cake/admin_addedit_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 RSpec.describe SoapyCake::AdminAddedit do
+  # rubocop:disable RSpec/NestedGroups
   subject(:admin_addedit) { described_class.new }
 
   around { |example| Timecop.freeze(Time.utc(2015, 2, 17, 12), &example) }

--- a/spec/lib/soapy_cake/admin_addedit_spec.rb
+++ b/spec/lib/soapy_cake/admin_addedit_spec.rb
@@ -3,6 +3,7 @@ RSpec.describe SoapyCake::AdminAddedit do
   subject(:admin_addedit) { described_class.new }
 
   before do
+    # rubocop:disable RSpec/SubjectStub
     allow(admin_addedit).to receive(:run).and_return({})
   end
 

--- a/spec/lib/soapy_cake/admin_batched_spec.rb
+++ b/spec/lib/soapy_cake/admin_batched_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe SoapyCake::AdminBatched do
   subject(:admin_batched) { described_class.new }
   let(:admin) { instance_double(SoapyCake::Admin, xml_response?: false) }
 
-  before :each do
+  before do
     allow(SoapyCake::Admin).to receive(:new).and_return(admin)
 
     stub_const('SoapyCake::AdminBatched::BatchedRequest::LIMIT', 2)

--- a/spec/lib/soapy_cake/admin_spec.rb
+++ b/spec/lib/soapy_cake/admin_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 RSpec.describe SoapyCake::Admin do
+  # rubocop:disable RSpec/NestedGroups
   subject(:admin) { described_class.new }
   let(:opts) { nil }
   let(:cake_opts) { opts }

--- a/spec/lib/soapy_cake/affiliate_spec.rb
+++ b/spec/lib/soapy_cake/affiliate_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe SoapyCake::Affiliate do
       request = instance_double(SoapyCake::Request)
       expect(SoapyCake::Request).to receive(:new)
         .with(:affiliate, service, method, cake_opts).and_return(request)
+      # rubocop:disable RSpec/SubjectStub
       expect(affiliate).to receive(:run).with(request)
 
       affiliate.public_send(method, opts)


### PR DESCRIPTION
Setting `add_edit_option` to "add" only adds the missing geos. It does
not remove the ones missing from the list provided with the call. Using
"replace" instead does that and still works for adding geos the first
time.

Fixes https://trello.com/c/kBRrPMnN/1328-bug-oct-does-not-exclude-some-countries-in-ww-offers