### PR TITLE
Re-add `AdminAddedit#add_geo_targets`

### DIFF
--- a/lib/soapy_cake/admin_addedit.rb
+++ b/lib/soapy_cake/admin_addedit.rb
@@ -111,6 +111,10 @@ module SoapyCake
       run Request.new(:admin, :addedit, :contact, opts)
     end
 
+    def add_geo_targets(opts)
+      edit_geo_targets(opts.merge(add_edit_option: 'add'))
+    end
+
     def edit_geo_targets(opts)
       require_params(opts, %i(offer_contract_id allow_countries))
 
@@ -120,7 +124,8 @@ module SoapyCake
                geo_targets_redirect_options(opts)
              end
 
-      opts = opts.merge(add_edit_option: 'replace', set_targeting_to_geo: true)
+      opts[:add_edit_option] ||= 'replace'
+      opts[:set_targeting_to_geo] = true
 
       run Request.new(:admin, :addedit, :geo_targets, opts)
     end

--- a/spec/lib/soapy_cake/admin_addedit_spec.rb
+++ b/spec/lib/soapy_cake/admin_addedit_spec.rb
@@ -83,4 +83,56 @@ RSpec.describe SoapyCake::AdminAddedit do
       admin_addedit.add_offer(offer_params.merge(tags: 'tag', tags_replace: true))
     end
   end
+
+  describe '#edit_geo_targets' do
+    let(:base_opts) do
+      {
+        offer_contract_id: 1,
+        allow_countries: true,
+        countries: %w(DE)
+      }
+    end
+
+    it 'replaces the existing config by default' do
+      expect(SoapyCake::Request).to receive(:new)
+        .with(:admin, :addedit, :geo_targets,
+          hash_including(add_edit_option: 'replace'))
+
+      admin_addedit.edit_geo_targets(base_opts)
+    end
+
+    it 'allows to override the add_edit_option' do
+      expect(SoapyCake::Request).to receive(:new)
+        .with(:admin, :addedit, :geo_targets,
+          hash_including(add_edit_option: 'add'))
+
+      admin_addedit.edit_geo_targets(base_opts.merge(add_edit_option: 'add'))
+    end
+
+    it 'does not mutate the passed options' do
+      allow(SoapyCake::Request).to receive(:new)
+
+      opts_before = base_opts.dup
+      admin_addedit.edit_geo_targets(base_opts)
+      expect(base_opts).to eq(opts_before)
+    end
+  end
+
+  describe '#add_geo_targets' do
+    let(:base_opts) do
+      {
+        offer_contract_id: 1,
+        allow_countries: true,
+        countries: %w(DE)
+      }
+    end
+
+    it 'adds geo targets' do
+      expect(SoapyCake::Request).to receive(:new)
+        .with(:admin, :addedit, :geo_targets,
+          hash_including(add_edit_option: 'add'))
+
+      admin_addedit.add_geo_targets(base_opts)
+    end
+  end
 end


### PR DESCRIPTION
In order to be able to subsequently add allowed and disallowed geo
targets, it is still necessary to make the `add` call.