### PR TITLE
Updating Saxerator breaks soapy cake behaviour.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :development, :test do
-  gem 'rubocop-ci', github: 'ad2games/rubocop-ci'
+  gem 'rubocop-ci', git: 'https://github.com/ad2games/rubocop-ci'
   gem 'simplecov'
   gem 'codeclimate-test-reporter', require: false
 end

--- a/lib/soapy_cake/helper.rb
+++ b/lib/soapy_cake/helper.rb
@@ -5,9 +5,9 @@ module SoapyCake
       return nil if obj == {}
 
       case obj
-      when Hash
+      when Hash, Saxerator::Builder::HashElement
         obj.map { |hk, hv| [hk, walk_tree(hv, hk, &block)] }.to_h
-      when Array
+      when Array, Saxerator::Builder::ArrayElement
         obj.map { |av| walk_tree(av, &block) }
       else
         yield(obj, key)

--- a/lib/soapy_cake/version.rb
+++ b/lib/soapy_cake/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module SoapyCake
-  VERSION = '2.1.0'
+  VERSION = '2.1.1'
 end

--- a/spec/integration/soapy_cake/admin_addedit_spec.rb
+++ b/spec/integration/soapy_cake/admin_addedit_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 RSpec.describe SoapyCake::AdminAddedit do
-  # rubocop:disable RSpec/NestedGroups
   subject(:admin_addedit) { described_class.new }
 
   around { |example| Timecop.freeze(Time.utc(2015, 2, 17, 12), &example) }

--- a/spec/lib/soapy_cake/admin_spec.rb
+++ b/spec/lib/soapy_cake/admin_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 RSpec.describe SoapyCake::Admin do
-  # rubocop:disable RSpec/NestedGroups
   subject(:admin) { described_class.new }
   let(:opts) { nil }
   let(:cake_opts) { opts }


### PR DESCRIPTION
New saxerator versions don't return a Hash directly anymore.