### PR TITLE
Change `auto_disposition_delay_hours` default value

### DIFF
--- a/lib/soapy_cake/campaigns.rb
+++ b/lib/soapy_cake/campaigns.rb
@@ -25,7 +25,7 @@ module SoapyCake
       paid_redirects: 'no_change',
       paid_upsells: 'no_change',
       review: 'no_change',
-      auto_disposition_delay_hours: 0,
+      auto_disposition_delay_hours: -1,
       redirect_offer_contract_id: 0,
       redirect_404: 'no_change',
       clear_session_on_conversion: 'no_change',

--- a/spec/fixtures/vcr_cassettes/SoapyCake_AdminAddedit/campaigns/edits_a_campaign.yml
+++ b/spec/fixtures/vcr_cassettes/SoapyCake_AdminAddedit/campaigns/edits_a_campaign.yml
@@ -14,7 +14,7 @@ http_interactions:
               <cake:api_key>cake-api-key</cake:api_key>
               <cake:display_link_type_id>1</cake:display_link_type_id>
               <cake:account_status_id>1</cake:account_status_id>
-              <cake:auto_disposition_delay_hours>0</cake:auto_disposition_delay_hours>
+              <cake:auto_disposition_delay_hours>-1</cake:auto_disposition_delay_hours>
               <cake:clear_session_on_conversion>no_change</cake:clear_session_on_conversion>
               <cake:currency_id>0</cake:currency_id>
               <cake:expiration_date>1970-01-01T01:00:00</cake:expiration_date>

--- a/spec/fixtures/vcr_cassettes/SoapyCake_Campaigns/_patch/different_pre-existing_values/does_not_change_anything_unintentionally_attribute_set_0_.yml
+++ b/spec/fixtures/vcr_cassettes/SoapyCake_Campaigns/_patch/different_pre-existing_values/does_not_change_anything_unintentionally_attribute_set_0_.yml
@@ -246,7 +246,7 @@ http_interactions:
               <cake:paid_redirects>no_change</cake:paid_redirects>
               <cake:paid_upsells>no_change</cake:paid_upsells>
               <cake:review>no_change</cake:review>
-              <cake:auto_disposition_delay_hours>0</cake:auto_disposition_delay_hours>
+              <cake:auto_disposition_delay_hours>-1</cake:auto_disposition_delay_hours>
               <cake:redirect_offer_contract_id>0</cake:redirect_offer_contract_id>
               <cake:redirect_404>no_change</cake:redirect_404>
               <cake:clear_session_on_conversion>no_change</cake:clear_session_on_conversion>

--- a/spec/fixtures/vcr_cassettes/SoapyCake_Campaigns/_patch/different_pre-existing_values/does_not_change_anything_unintentionally_attribute_set_1_.yml
+++ b/spec/fixtures/vcr_cassettes/SoapyCake_Campaigns/_patch/different_pre-existing_values/does_not_change_anything_unintentionally_attribute_set_1_.yml
@@ -248,7 +248,7 @@ http_interactions:
               <cake:paid_redirects>no_change</cake:paid_redirects>
               <cake:paid_upsells>no_change</cake:paid_upsells>
               <cake:review>no_change</cake:review>
-              <cake:auto_disposition_delay_hours>0</cake:auto_disposition_delay_hours>
+              <cake:auto_disposition_delay_hours>-1</cake:auto_disposition_delay_hours>
               <cake:redirect_offer_contract_id>0</cake:redirect_offer_contract_id>
               <cake:redirect_404>no_change</cake:redirect_404>
               <cake:clear_session_on_conversion>no_change</cake:clear_session_on_conversion>

--- a/spec/fixtures/vcr_cassettes/SoapyCake_Campaigns/_patch/updates_a_campaign.yml
+++ b/spec/fixtures/vcr_cassettes/SoapyCake_Campaigns/_patch/updates_a_campaign.yml
@@ -95,7 +95,7 @@ http_interactions:
               <cake:paid_redirects>no_change</cake:paid_redirects>
               <cake:paid_upsells>no_change</cake:paid_upsells>
               <cake:review>no_change</cake:review>
-              <cake:auto_disposition_delay_hours>0</cake:auto_disposition_delay_hours>
+              <cake:auto_disposition_delay_hours>-1</cake:auto_disposition_delay_hours>
               <cake:redirect_offer_contract_id>0</cake:redirect_offer_contract_id>
               <cake:redirect_404>no_change</cake:redirect_404>
               <cake:clear_session_on_conversion>no_change</cake:clear_session_on_conversion>
@@ -320,7 +320,7 @@ http_interactions:
               <cake:paid_redirects>no_change</cake:paid_redirects>
               <cake:paid_upsells>no_change</cake:paid_upsells>
               <cake:review>no_change</cake:review>
-              <cake:auto_disposition_delay_hours>0</cake:auto_disposition_delay_hours>
+              <cake:auto_disposition_delay_hours>-1</cake:auto_disposition_delay_hours>
               <cake:redirect_offer_contract_id>0</cake:redirect_offer_contract_id>
               <cake:redirect_404>no_change</cake:redirect_404>
               <cake:clear_session_on_conversion>no_change</cake:clear_session_on_conversion>

--- a/spec/fixtures/vcr_cassettes/SoapyCake_Campaigns/_update/raises_an_error_if_the_update_was_unsuccessful.yml
+++ b/spec/fixtures/vcr_cassettes/SoapyCake_Campaigns/_update/raises_an_error_if_the_update_was_unsuccessful.yml
@@ -21,7 +21,7 @@ http_interactions:
               <cake:paid_redirects>no_change</cake:paid_redirects>
               <cake:paid_upsells>no_change</cake:paid_upsells>
               <cake:review>no_change</cake:review>
-              <cake:auto_disposition_delay_hours>0</cake:auto_disposition_delay_hours>
+              <cake:auto_disposition_delay_hours>-1</cake:auto_disposition_delay_hours>
               <cake:redirect_offer_contract_id>0</cake:redirect_offer_contract_id>
               <cake:redirect_404>no_change</cake:redirect_404>
               <cake:clear_session_on_conversion>no_change</cake:clear_session_on_conversion>

--- a/spec/fixtures/vcr_cassettes/SoapyCake_Campaigns/_update/updates_campaigns.yml
+++ b/spec/fixtures/vcr_cassettes/SoapyCake_Campaigns/_update/updates_campaigns.yml
@@ -21,7 +21,7 @@ http_interactions:
               <cake:paid_redirects>no_change</cake:paid_redirects>
               <cake:paid_upsells>no_change</cake:paid_upsells>
               <cake:review>no_change</cake:review>
-              <cake:auto_disposition_delay_hours>0</cake:auto_disposition_delay_hours>
+              <cake:auto_disposition_delay_hours>-1</cake:auto_disposition_delay_hours>
               <cake:redirect_offer_contract_id>0</cake:redirect_offer_contract_id>
               <cake:redirect_404>no_change</cake:redirect_404>
               <cake:clear_session_on_conversion>no_change</cake:clear_session_on_conversion>


### PR DESCRIPTION
The CAKE support's reply to a support request regarding errors we
suddenly got:

> We made a release two days ago on the Addedit Campaign V3 API - the
> field ‘auto_disposition_delay_hours’ was setting a -1 automatically
> which has now been fixed. The following parameters are now accepted for
> auto_disposition_delay_hours:
>
> “-1”: null on add, skip on edit
> “-2": clear field/null on add and edit
> “0” or less than “-2": invalid inputs on add and edit