### PR TITLE
Mass conversion insert API version 2

### DIFF
--- a/api.yml
+++ b/api.yml
@@ -98,8 +98,7 @@ versions:
       conversion_dispositions: 2
       decrypt_affiliate_link: 1
       mass_conversion_adjustment: 2
-      # Version 2 returns an error about an invalid action, so using version 1
-      mass_conversion_insert: 1
+      mass_conversion_insert: 2
       rejected_dispositions: 1
       update_conversion: 4
       update_conversion_disposition: 2

--- a/lib/soapy_cake/admin_track.rb
+++ b/lib/soapy_cake/admin_track.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'soapy_cake/request_mass_conversion_insert'
+
 module SoapyCake
   class AdminTrack < Client
     include Helper
@@ -21,7 +23,7 @@ module SoapyCake
                        campaign_id creative_id total_to_insert
                      ])
 
-      run Request.new(:admin, :track, :mass_conversion_insert, opts)
+      run RequestMassConversionInsert.new(:admin, :track, :mass_conversion_insert, opts)
     end
 
     def update_conversion(opts)

--- a/lib/soapy_cake/request_mass_conversion_insert.rb
+++ b/lib/soapy_cake/request_mass_conversion_insert.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module SoapyCake
+  class RequestMassConversionInsert < Request
+    private
+
+    # There is a bug in MassConversionInsert version 2 API in cake,
+    # in which xmlns is still using version 1.
+    def xml_namespaces
+      {
+        'xmlns:env' => 'http://www.w3.org/2003/05/soap-envelope',
+        'xmlns:cake' => 'http://cakemarketing.com/api/1/'
+      }
+    end
+  end
+end

--- a/lib/soapy_cake/version.rb
+++ b/lib/soapy_cake/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SoapyCake
-  VERSION = '2.1.5'
+  VERSION = '2.1.6'
 end

--- a/soapy_cake.gemspec
+++ b/soapy_cake.gemspec
@@ -32,4 +32,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'webmock'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'timecop'
+  spec.add_development_dependency 'dotenv'
 end

--- a/spec/fixtures/vcr_cassettes/SoapyCake_AdminTrack/_mass_conversion_insert/inserts_conversions.yml
+++ b/spec/fixtures/vcr_cassettes/SoapyCake_AdminTrack/_mass_conversion_insert/inserts_conversions.yml
@@ -2,9 +2,9 @@
 http_interactions:
 - request:
     method: post
-    uri: https://cake-partner-domain.com/api/1/track.asmx
+    uri: https://cake-partner-domain.com/api/2/track.asmx
     body:
-      encoding: UTF-8
+      encoding: ASCII-8BIT
       string: |
         <?xml version="1.0"?>
         <env:Envelope xmlns:env="http://www.w3.org/2003/05/soap-envelope" xmlns:cake="http://cakemarketing.com/api/1/">
@@ -12,18 +12,28 @@ http_interactions:
           <env:Body>
             <cake:MassConversionInsert>
               <cake:api_key>cake-api-key</cake:api_key>
-              <cake:conversion_date>2015-05-06T02:00:00</cake:conversion_date>
+              <cake:conversion_date>2015-05-07T02:00:00</cake:conversion_date>
               <cake:affiliate_id>16059</cake:affiliate_id>
               <cake:campaign_id>13268</cake:campaign_id>
               <cake:sub_affiliate/>
               <cake:creative_id>5521</cake:creative_id>
-              <cake:total_to_insert>12</cake:total_to_insert>
+              <cake:total_to_insert>3</cake:total_to_insert>
+              <cake:note>Test created on 2017-07-24</cake:note>
+              <cake:payout>0.1</cake:payout>
+              <cake:received>0.2</cake:received>
+              <cake:transaction_ids>test-transaction-id-1,test-transaction-id-2,test-transaction-id-3</cake:transaction_ids>
             </cake:MassConversionInsert>
           </env:Body>
         </env:Envelope>
     headers:
       Content-Type:
       - application/soap+xml;charset=UTF-8
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
   response:
     status:
       code: 200
@@ -31,18 +41,18 @@ http_interactions:
     headers:
       Cache-Control:
       - private, max-age=0
+      Content-Length:
+      - '464'
       Content-Type:
       - application/soap+xml; charset=utf-8
-      Server:
-      - Microsoft-IIS/8.0
+      Date:
+      - Mon, 24 Jul 2017 19:42:39 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Powered-By:
       - ASP.NET
-      Date:
-      - Wed, 06 May 2015 12:35:51 GMT
-      Content-Length:
-      - '464'
+      Connection:
+      - close
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope"
@@ -50,5 +60,5 @@ http_interactions:
         xmlns="http://cakemarketing.com/api/1/"><MassConversionInsertResult><success>true</success><message>Conversions
         Inserted</message></MassConversionInsertResult></MassConversionInsertResponse></soap:Body></soap:Envelope>
     http_version: 
-  recorded_at: Wed, 06 May 2015 12:35:53 GMT
-recorded_with: VCR 2.9.3
+  recorded_at: Mon, 24 Jul 2017 19:42:40 GMT
+recorded_with: VCR 3.0.3

--- a/spec/integration/soapy_cake/admin_track_spec.rb
+++ b/spec/integration/soapy_cake/admin_track_spec.rb
@@ -8,12 +8,16 @@ RSpec.describe SoapyCake::AdminTrack do
   describe '#mass_conversion_insert', :vcr do
     it 'inserts conversions' do
       result = admin_track.mass_conversion_insert(
-        conversion_date: Date.new(2015, 5, 6),
+        conversion_date: Date.new(2015, 5, 7),
         affiliate_id: 16059,
         campaign_id: 13268,
         sub_affiliate: '',
         creative_id: 5521,
-        total_to_insert: 12
+        total_to_insert: 3,
+        note: "Test created on #{Date.current}",
+        payout: 0.1,
+        received: 0.2,
+        transaction_ids: (1..3).map { |i| "test-transaction-id-#{i}" }.join(',')
       )
 
       expect(result).to eq(success: true, message: 'Conversions Inserted')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'dotenv/load'
 require 'simplecov'
 SimpleCov.start do
   add_filter '/spec/'


### PR DESCRIPTION
For [Include 'Add Branding Campaign' to Mass Adjustment Tool in BO](https://trello.com/c/9g0ObTYP) we need to create _approved_ conversions in Cake.

The API to create manual conversions in Cake is `MassConversionInsert`. The problem is that conversions created by the API are **not** approved. To approve them we need to use the `UpdateConversion` API. But `MassConversionInsert` doesn't give us `conversion_ids` that were created.

The `UpdateConversion` API allows the use of `transaction_id` as alternative conversion identifier, but only version 2 of `MassConversionInsert` can set the conversion `transaction_id`.

The `MassConversionInsert` was downgraded to version 1 because of an "invalid action" error in version 2.

So I figure out a way to fix the error in version 2, so we can use it to set conversion `transaction_id` and then use `UpdateConversion` to approve it.