### PR TITLE
Add text, html and video creative types.

### DIFF
--- a/lib/soapy_cake/const.rb
+++ b/lib/soapy_cake/const.rb
@@ -73,10 +73,14 @@ module SoapyCake
         custom: 4
       },
       creative_type_id: {
+        # taken from https://support.getcake.com/support/solutions/articles/5000546087-addedit-creative-api-version-1
         link: 1,
         email: 2,
         image: 3,
-        flash: 4
+        flash: 4,
+        text: 5,
+        html: 6,
+        video: 7
       },
       creative_status_id: {
         active: 1,

--- a/lib/soapy_cake/version.rb
+++ b/lib/soapy_cake/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SoapyCake
-  VERSION = '2.2.0'
+  VERSION = '2.2.1'
 end


### PR DESCRIPTION
Values were taken from https://support.getcake.com/support/solutions/articles/5000546087-addedit-creative-api-version-1

This fixes ActiveRecord::RecordInvalid error when importing creatives in Backoffice.
https://app.bugsnag.com/ad2games/backoffice/errors/597b9b59efb700001920e0e7