### PR TITLE
Add more request related information to RequestFailed exception

### DIFF
--- a/lib/soapy_cake/client.rb
+++ b/lib/soapy_cake/client.rb
@@ -82,7 +82,12 @@ module SoapyCake
       response = perform_http_request(http_request)
 
       unless response.is_a?(Net::HTTPSuccess)
-        raise RequestFailed, "Request failed with HTTP #{response.code}: #{response.body}"
+        raise RequestFailed.new(
+          "Request failed with HTTP #{response.code}",
+          request_path: request.path,
+          request_body: http_request.body,
+          response_body: response.body
+        )
       end
 
       response.body

--- a/lib/soapy_cake/client.rb
+++ b/lib/soapy_cake/client.rb
@@ -36,7 +36,7 @@ module SoapyCake
 
     protected
 
-    attr_reader :domain, :api_key, :time_converter, :opts, :logger, :retry_count, :write_enabled
+    attr_reader :domain, :api_key, :time_converter, :opts, :retry_count, :write_enabled
 
     private
 

--- a/lib/soapy_cake/error.rb
+++ b/lib/soapy_cake/error.rb
@@ -2,6 +2,17 @@
 
 module SoapyCake
   class Error < RuntimeError; end
-  class RequestFailed < Error; end
+
+  class RequestFailed < Error
+    attr_reader :request_path, :request_body, :response_body
+
+    def initialize(message, request_path: nil, request_body: nil, response_body: nil)
+      @request_path = request_path
+      @request_body = request_body
+      @response_body = response_body
+      super(message)
+    end
+  end
+
   class RateLimitError < RequestFailed; end
 end

--- a/lib/soapy_cake/error.rb
+++ b/lib/soapy_cake/error.rb
@@ -8,7 +8,7 @@ module SoapyCake
 
     def initialize(message, request_path: nil, request_body: nil, response_body: nil)
       @request_path = request_path
-      @request_body = request_body
+      @request_body = request_body&.sub(ENV.fetch('CAKE_API_KEY'), '[redacted]')
       @response_body = response_body
       super(message)
     end

--- a/soapy_cake.gemspec
+++ b/soapy_cake.gemspec
@@ -1,4 +1,3 @@
-# coding: utf-8
 # frozen_string_literal: true
 
 lib = File.expand_path('../lib', __FILE__)
@@ -21,16 +20,16 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'activesupport'
-  spec.add_dependency 'saxerator'
   spec.add_dependency 'nokogiri'
   spec.add_dependency 'retryable'
+  spec.add_dependency 'saxerator'
 
   spec.add_development_dependency 'bundler'
+  spec.add_development_dependency 'dotenv'
+  spec.add_development_dependency 'pry'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '>= 3.0.0'
+  spec.add_development_dependency 'timecop'
   spec.add_development_dependency 'vcr'
   spec.add_development_dependency 'webmock'
-  spec.add_development_dependency 'pry'
-  spec.add_development_dependency 'timecop'
-  spec.add_development_dependency 'dotenv'
 end

--- a/spec/integration/soapy_cake/admin_spec.rb
+++ b/spec/integration/soapy_cake/admin_spec.rb
@@ -66,9 +66,12 @@ RSpec.describe SoapyCake::Admin do
   end
 
   it 'raises if there is an error', :vcr do
-    expect do
-      admin.affiliates(affiliate_id: 'bloops')
-    end.to raise_error(SoapyCake::RequestFailed)
+    expect { admin.affiliates(affiliate_id: 'bloops') }
+      .to raise_error(SoapyCake::RequestFailed) do |e|
+        expect(e.request_path).to eq('/api/5/export.asmx')
+        expect(e.request_body).to include('<cake:affiliate_id>bloops</cake:affiliate_id>')
+        expect(e.response_body).to include('There is an error in XML document')
+      end
   end
 
   it 'creates an affiliate and returns the ID', :vcr do

--- a/spec/lib/soapy_cake/request_failed_spec.rb
+++ b/spec/lib/soapy_cake/request_failed_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+RSpec.describe SoapyCake::RequestFailed do
+  it 'has request related attributes' do
+    error = described_class.new(
+      'Boo!',
+      request_path: 'request path',
+      request_body: 'request body',
+      response_body: 'response body'
+    )
+    expect(error).to have_attributes(
+      'request_path' => 'request path',
+      'request_body' => 'request body',
+      'response_body' => 'response body'
+    )
+  end
+
+  it 'redacts the API key from the request body' do
+    error = described_class.new('Boo!', request_body: ">#{ENV.fetch('CAKE_API_KEY')}<")
+    expect(error.request_body).to eq('>[redacted]<')
+  end
+end

--- a/spec/lib/soapy_cake/response_spec.rb
+++ b/spec/lib/soapy_cake/response_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe SoapyCake::Response do
   let(:xml) do
-    <<-EOD
+    <<-XML
       <?xml version="1.0" encoding="utf-8"?>
       <soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope">
         <soap:Body>
@@ -22,7 +22,7 @@ RSpec.describe SoapyCake::Response do
           </SomeResponse>
         </soap:Body>
       </soap:Envelope>
-    EOD
+    XML
   end
 
   subject(:response) { described_class.new(xml.strip, false, 0) }
@@ -32,9 +32,6 @@ RSpec.describe SoapyCake::Response do
   end
 
   it 'parses the CAKE XML structure properly' do
-    expect(response.to_enum.to_a).to eq([
-                                          { id: '123' },
-                                          { id: '312' }
-                                        ])
+    expect(response.to_enum.to_a).to eq([{ id: '123' }, { id: '312' }])
   end
 end

--- a/spec/lib/soapy_cake/time_converter_spec.rb
+++ b/spec/lib/soapy_cake/time_converter_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable Style/DateTime
 RSpec.describe SoapyCake::TimeConverter do
   subject(:time_converter) { described_class.new('Europe/Berlin') }
 
@@ -37,3 +38,4 @@ RSpec.describe SoapyCake::TimeConverter do
     end
   end
 end
+# rubocop:enable Style/DateTime


### PR DESCRIPTION
In order to easily be able to look up the request body of a failed request, so we can sent it to CAKE's support if necessary, let's add this information to the exception.